### PR TITLE
Return file descriptor for the file console wraps. 

### DIFF
--- a/console.go
+++ b/console.go
@@ -53,18 +53,17 @@ func Stderr() *Console {
 // Console manages state for output, typically stdout or stderr.
 type Console struct {
 	sync.Mutex
-	colored    io.Writer
-	noncolored io.Writer
-	current    io.Writer
+	colored        io.Writer
+	noncolored     io.Writer
+	current        io.Writer
 	fileDescriptor uintptr
-
 }
 
 // NewConsole creates a wrapper around out which will output platform independent colored text.
 func NewConsole(out *os.File) *Console {
 	c := &Console{
-		colored:    colorable.NewColorable(out),
-		noncolored: colorable.NewNonColorable(out),
+		colored:        colorable.NewColorable(out),
+		noncolored:     colorable.NewNonColorable(out),
 		fileDescriptor: out.Fd(),
 	}
 	if Enabled() {
@@ -75,7 +74,7 @@ func NewConsole(out *os.File) *Console {
 	return c
 }
 
-func(c Console) Fd() uintptr {
+func (c *Console) Fd() uintptr {
 	c.Lock()
 	defer c.Unlock()
 	return c.fileDescriptor

--- a/console.go
+++ b/console.go
@@ -56,6 +56,8 @@ type Console struct {
 	colored    io.Writer
 	noncolored io.Writer
 	current    io.Writer
+	fileDescriptor uintptr
+
 }
 
 // NewConsole creates a wrapper around out which will output platform independent colored text.
@@ -63,6 +65,7 @@ func NewConsole(out *os.File) *Console {
 	c := &Console{
 		colored:    colorable.NewColorable(out),
 		noncolored: colorable.NewNonColorable(out),
+		fileDescriptor: out.Fd(),
 	}
 	if Enabled() {
 		c.current = c.colored
@@ -70,6 +73,12 @@ func NewConsole(out *os.File) *Console {
 	}
 	c.current = c.noncolored
 	return c
+}
+
+func(c Console) Fd() uintptr {
+	c.Lock()
+	defer c.Unlock()
+	return c.fileDescriptor
 }
 
 // DisableColors if true ANSI color information will be removed for this console object. Passing true will enable

--- a/console_test.go
+++ b/console_test.go
@@ -97,3 +97,10 @@ func TestConsoleEnable(t *testing.T) {
 	want := "foo\x1b[31mbar\x1b[0m"
 	assertEqualS(t, outf(), want)
 }
+
+func TestFileDescriptor(t *testing.T) {
+	c := NewConsole(os.Stdout)
+	if c.Fd() != os.Stdout.Fd() {
+		t.Fatalf("fd mismatch stdout %X console %X", os.Stdout.Fd(), c.Fd())
+	}
+}


### PR DESCRIPTION
This is needed to assess terminal capabilities in pack. 